### PR TITLE
Added json header to API response

### DIFF
--- a/api/incidents.php
+++ b/api/incidents.php
@@ -13,6 +13,7 @@ else{
   $timestamp = (isset($_GET['timestamp']))?$_GET['timestamp']:time();
 
 	$result = $constellation->get_incidents((isset($_GET['future'])?$_GET['future']:false), $offset, $limit, $timestamp);
-	
+	header('Cache-Control: no-cache');
+	header('Content-type: application/json');
 	echo json_encode($result);
 }

--- a/api/status.php
+++ b/api/status.php
@@ -7,6 +7,8 @@ if (!file_exists("../config.php"))
 else{
   require_once("../config.php");
   require_once("../classes/constellation.php");
+  header('Cache-Control: no-cache');
+  header('Content-type: application/json');
 
   if (!isset($_GET['id']))
   {


### PR DESCRIPTION
I've just started to play with your API. Using Postman, I've discovered that the ```application/json``` header is missing:
![Missing json header in postman](https://i.imgur.com/98oiZax.png)

So I've added the following headers to the response:
```php
header('Cache-Control: no-cache');
header('Content-type: application/json');
```
It tells the browser to not cache the response and that the response is in json format. Now Postman recognize it:

![Postman with json header](
https://i.imgur.com/048ijrN.png)