### PR TITLE
Add prerequisite and policy url configuration

### DIFF
--- a/config.php.template
+++ b/config.php.template
@@ -12,6 +12,7 @@ define("ADDRESS", "##address##");
 define("POLICY_MAIL", "##policy_mail##"); //contact email in policy
 define("POLICY_PHONE", "##policy_phone##");
 define("WHO_WE_ARE","##who_we_are##");
+define("POLICY_URL","##policy_url##");
 define("INSTALL_OVERRIDE", false);
 define("DEFAULT_LANGUAGE", "en_GB");
 

--- a/install.php
+++ b/install.php
@@ -3,6 +3,7 @@ require_once("template.php");
 define("WEB_URL", "."); //Website name
 define("NAME", _('Status page')); //Website name
 define("MINIMUM_PHP_VERSION", "5.4.0");
+define("POLICY_URL", "policy.php"); //Default policy URL
 require_once("classes/locale-negotiator.php");
 
 $negotiator = new LocaleNegotiator("en_GB");
@@ -127,6 +128,8 @@ if(isset($_POST['server']) && empty($message))
 		$config = str_replace("##policy_mail##", $_POST['policy_mail'], $config);
 		$config = str_replace("##policy_phone##", $_POST['policy_phone'],$config);
 		$config = str_replace("##who_we_are##", $_POST['who_we_are'], $config);
+		$policy_url_conf = ( ! empty($_POST['policy_url']) ) ? $_POST['policy_url'] : POLICY_URL;
+		$config = str_replace("##policy_url##", $policy_url_conf, $config);
 		file_put_contents("config.php", $config);
 		
 
@@ -238,6 +241,12 @@ if (!empty($message))
 		</div>
 		<div class="form-group clearfix">
 			<div class=""><label for="who_we_are"><?php echo _("Who we are");?>: </label><textarea class="form-control" id="who_we_are" rows="3" name="who_we_are" placeholder="<?php echo _("Some info about yourself");?>" value="<?php echo ((isset($_POST['who_we_are']))?htmlspecialchars($_POST['who_we_are'], ENT_QUOTES):'');?>"></textarea></div>
+		</div>
+		<div class="form-group clearfix">
+			<div class="col-sm-12"><label for="url"><?php echo _("External Policy Url");?>: </label>
+				<summary><?php echo _("If you alredy have an existing Policy published, please provide the full Url to override the local policy definition. Leave blank to use the local definition");?></summary>
+				<input type="policy_url" name="policy_url" value="<?php echo ((isset($_POST['policy_url']))?htmlspecialchars($_POST['policy_url'], ENT_QUOTES):'');?>" id="policy_url" placeholder="<?php echo _("External Policy Url");?>" class="form-control">
+			</div>
 		</div>
 	</section>
 	<section class="install-section clearfix">

--- a/install.php
+++ b/install.php
@@ -2,6 +2,7 @@
 require_once("template.php");
 define("WEB_URL", "."); //Website name
 define("NAME", _('Status page')); //Website name
+define("MINIMUM_PHP_VERSION", "5.4.0");
 require_once("classes/locale-negotiator.php");
 
 $negotiator = new LocaleNegotiator("en_GB");
@@ -138,6 +139,47 @@ if(isset($_POST['server']) && empty($message))
 }
 Template::render_header(_("Install"));
 ?>
+<h1 class="text-center"><?php echo _("Prerequisite");?></h1>
+<summary><?php echo _("If any of the following prerequisites are shown as failed (red X), please correct the issue and reload the page before proceeding with the installation.");?></summary>
+<?php
+
+
+	$php_version_req = sprintf(_("Minimum PHP version %s"), MINIMUM_PHP_VERSION);
+    $preq_fail = array("remove", "danger");
+	$preq_ok   = array("ok", "success");
+
+	$preq_phpver = $preq_fail;
+	$preq_mysqlnd = $preq_fail;
+	$preq_writedir = $preq_fail;
+
+	// Check if PHP version if > MINIMUM_PHP_VERSION
+	if (strnatcmp(phpversion(), MINIMUM_PHP_VERSION) >= 0) { $preq_phpver = $preq_ok; }
+
+	// Check if we have mysqlnd installed
+	if ( function_exists('mysqli_get_client_stats') ) { $preq_mysqlnd = $preq_ok; }
+
+	// Check if we have access to write to location
+	if ( is_writable(__DIR__) ) { $preq_writedir = $preq_ok; }
+
+?>
+    <section class="prereq-section clearfix">
+  		<div class="container-fluid">
+			<div class="row ">
+		    	<div class="col-md-6 text-right"><label for="php version"><?php echo $php_version_req;?></div>
+	            <div class="col-md-6"><a href="#" class="btn btn-<?php echo $preq_phpver[1];?>"><span class="glyphicon glyphicon-<?php echo $preq_phpver[0]; ?>"></span></a></div>
+			</div>
+			<div class="row ">
+		    	<div class="col-md-6 text-right"><label for="mysqlnd Library installed"><?php echo _('PHP mysqlnd library installed');?></div>
+	            <div class="col-md-6"><a href="#" class="btn btn-<?php echo $preq_mysqlnd[1];?>"><span class="glyphicon glyphicon-<?php echo $preq_mysqlnd[0]; ?>"></span></a></div>
+			</div>
+            <div class="row">
+				<div class="col-md-6 text-right"><label for="write_access"><?php  echo _('Write access to web directory');?></div>
+	            <div class="col-md-6"><a href="#" class="btn btn-<?php echo $preq_writedir[1];?>"><span class="glyphicon glyphicon-<?php echo $preq_writedir[0]; ?>"></span></a></div>
+			</div>
+		</div>
+
+	</section>
+
 <h1 class="text-center"><?php echo _("Installation");?></h1>
 <?php
 if (!empty($message))

--- a/install.php
+++ b/install.php
@@ -158,7 +158,10 @@ Template::render_header(_("Install"));
 	// Check if PHP version if > MINIMUM_PHP_VERSION
 	if (strnatcmp(phpversion(), MINIMUM_PHP_VERSION) >= 0) { $preq_phpver = $preq_ok; }
 
-	// Check if we have mysqlnd installed
+	// Test for mysqlnd precense.  The mysqlnd driver provides some extra functions that is not available 
+	// if the plain mysql package is installed, and mysqli_get_client_stats is one of them. This is documented 
+	// on the PHP site at http://www.php.net/manual/en/mysqlnd.stats.php
+	// This test is also discussed at https://stackoverflow.com/questions/1475701/how-to-know-if-mysqlnd-is-the-active-driver
 	if ( function_exists('mysqli_get_client_stats') ) { $preq_mysqlnd = $preq_ok; }
 
 	// Check if we have access to write to location

--- a/template.php
+++ b/template.php
@@ -138,7 +138,7 @@ class Template{
     <div id="footerwrap">
       <div class="container">
         <div class="row centered">
-          <div class="col-md-4 text-left">Copyright © <?php echo date("Y");?> Vojtěch Sajdl</div>
+          <div class="col-md-4 text-left"><a href="https://github.com/Pryx/server-status/" target="_blank"><i class="fab fa-github" aria-hidden="true"></i>&nbsp;</a>Copyright © <?php echo date("Y");?> Vojtěch Sajdl</div>
           <div class="col-md-4 text-center">
             <div class="btn-group dropup">
               <button type="button" class="btn btn-primary"><?php echo '<img src="'.WEB_URL.'/locale/'.$_SESSION['locale'].'/flag.png" alt="'.$lang_names[$_SESSION['locale']].'">'.$lang_names[$_SESSION['locale']];?></button>
@@ -157,7 +157,7 @@ class Template{
               </div>
             </div>
           </div>
-          <div class="col-md-4 text-right"><a href="policy.php">Imprint & Privacy Policy</a><a href="https://github.com/Pryx/server-status/" target="_blank"><i class="fab fa-github" aria-hidden="true"></i></a></div>
+          <div class="col-md-4 text-right"><a href="<?php echo POLICY_URL; ?>"><?php echo _("Imprint & Privacy Policy");?></a><!-- <a href="https://github.com/Pryx/server-status/" target="_blank"><i class="fab fa-github" aria-hidden="true"></i></a> --></div>
         </div><!--/row -->
       </div><!--/container -->
     </div>


### PR DESCRIPTION
Please find suggestion for to new options.

1. Provide the policy URL during installation. 
2. Prerequisite checks during install. 

For the policy setting, if none is given during installation, the default policy.php is used. The github icon on the footer is also moved to the left to prevent it looking like part of the Imprint/Privacy policy.

![image](https://user-images.githubusercontent.com/10619272/48201192-c3233f00-e361-11e8-91dc-4f2cc4f1c3ca.png)
![image](https://user-images.githubusercontent.com/10619272/48201223-d8986900-e361-11e8-989d-822e21fad8de.png)

The prerequisite checks during install that will check for the following:

* PHP Version (set to min 5.4 in this commit)
* Presence of mysqlnd library
* Write access to web directory

![image](https://user-images.githubusercontent.com/10619272/48201390-4fcdfd00-e362-11e8-8d09-c9bdac978863.png)

