### PR TITLE
Fix relative timestamps not properly displaying dates in the future.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,8 @@ function timeago()
 }
 
 (function(){
+	jQuery.timeago.settings.allowFuture = true;
+
 	timeago();
 	
 	$("body").on("click", ".navbar-toggle", function(){


### PR DESCRIPTION
In 184247c4abe777399a98f2711f47b2d6e1d5d57c (#99) jquery.timeago was updated from version 1.6.1 to 1.6.7.
This changed the default value for allowFuture, which is responsible for restricting whether a date in the future would be shown e.g. as "3 days ago" or "3 days from now".

![image](https://user-images.githubusercontent.com/3694534/84488502-92735c00-aca0-11ea-8dcc-ff2096913970.png)
