### PR TITLE
Fix service labels not fitting inside  container

### DIFF
--- a/classes/incident.php
+++ b/classes/incident.php
@@ -194,7 +194,7 @@ class Incident implements JsonSerializable
           <small>
               <?php echo _("Impacted service(s): ");
               foreach ( $this->service_name as $key => $value ) {
-                echo '<span class="label label-default" style="display:inline-block;">'.$value . '</span>&nbsp;';
+                echo '<span class="label label-default">'.$value . '</span>&nbsp;';
               }
 
           if (isset($this->end_date)){?> 

--- a/classes/incident.php
+++ b/classes/incident.php
@@ -194,7 +194,7 @@ class Incident implements JsonSerializable
           <small>
               <?php echo _("Impacted service(s): ");
               foreach ( $this->service_name as $key => $value ) {
-                echo '<span class="label label-default">'.$value . '</span>&nbsp;';
+                echo '<span class="label label-default" style="display:inline-block;">'.$value . '</span>&nbsp;';
               }
 
           if (isset($this->end_date)){?> 

--- a/css/main.css
+++ b/css/main.css
@@ -616,3 +616,7 @@ label.form-name
 {
 	line-height: 20px
 }
+.panel .panel-footer .label
+{
+    display: inline-block;
+}


### PR DESCRIPTION
Service Labels are automatically pushed to a new line when there is no enough space instead of making page wider.